### PR TITLE
#6: Report timestamps of modified pages

### DIFF
--- a/lib/urlwatch/command.py
+++ b/lib/urlwatch/command.py
@@ -313,7 +313,7 @@ class UrlwatchCommand:
             output += ("%s|%s\n" % (state[0], state[1]))
 
         if not running_after_jobs:
-        print(output)
+            print(output)
         
         config = self.urlwatcher.config_storage.config['report'].get('timestamp_webhook', None)
         if not config:

--- a/lib/urlwatch/config.py
+++ b/lib/urlwatch/config.py
@@ -104,6 +104,7 @@ class CommandConfig(BaseConfig):
         group = parser.add_argument_group('miscellaneous')
         group.add_argument('--features', action='store_true', help='list supported jobs/filters/reporters')
         group.add_argument('--gc-cache', action='store_true', help='remove old cache entries')
+        group.add_argument('--report-timestamps', action='store_true', help='report job timestamps')
 
         args = parser.parse_args()
 

--- a/lib/urlwatch/storage.py
+++ b/lib/urlwatch/storage.py
@@ -111,6 +111,10 @@ DEFAULT_CONFIG = {
             'enabled': False,
             'webhook_url': '',
         },
+        'timestamp_webhook': {
+            'enabled': False,
+            'webhook_url': '',
+        },
         'mailgun': {
             'enabled': False,
             'region': 'us',


### PR DESCRIPTION
https://github.com/COVID19Tracking/covid-tracking/issues/6. Adds —report-timestamps switch (and runs automatically after jobs complete if enabled in the config) to report the last-modified timestamps of tracked pages to a webhook