### PR TITLE
Add Requirements-Dev for easier contributor onboarding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__
 .idea
 build
+/venv

--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ urlwatch 2 requires:
 
 The dependencies can be installed with (add `--user` to install to `$HOME`):
 
-`python3 -m pip install pyyaml minidb requests keyring appdirs lxml cssselect`
+`python3 -m venv venv;source venv/bin/activate`
+
+`python3 -m pip install -r requirements-dev.txt`
 
 
 Optional dependencies (install via `python3 -m pip install <packagename>`):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,11 @@
+appdirs==1.4.3
+certifi==2019.11.28
+chardet==3.0.4
+cssselect==1.1.0
+idna==2.9
+keyring==21.2.0
+lxml==4.5.0
+minidb==2.0.2
+PyYAML==5.3.1
+requests==2.23.0
+urllib3==1.25.8


### PR DESCRIPTION
Adds a simple update to the README to activate `venv` and install dependencies from `requirements-dev.txt` using `pip install -r` command. Locks dev versions for easier collaboration/debugging. Git ignores the local `venv` directory to keep the project clean.

Happy to add the dependencies as `install_requires` option as well if `setup.py install --develop` is preferred 👍 